### PR TITLE
Added a link to the code of conduct to the about page.

### DIFF
--- a/server/views/about.html
+++ b/server/views/about.html
@@ -26,12 +26,14 @@ technical and social, about computer programming.
           <li>create a stronger tech and startup minded community in New Haven</li>
           <li>partner with other organizations to achieve these goals</li>
         </ul>
-        
+
         <p>
           If you want to help us build something here, please start
           contributing to <a href="http://github.com/newhavenio">our repo
           on GitHub</a>.
         </p>
+        <h2><strong>Code of Contact</strong></h2>
+        <p>All members of NewHaven.io are expected to abide by our code of coduct found <a href='https://github.com/newhavenio/code-of-conduct/blob/master/README.md'>here</a>.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Was going to add this to the header, but couldn't get the layout to work
with 5 links in the header.

The code of conduct repo was copied from http://contributor-covenant.org/. 
